### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": ">=2.1.*",
+        "symfony/symfony": ">=2.1",
         "doctrine/doctrine-bundle": "*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The version constraint `>=2.1.*` is not valid, it should be `>=2.1`

The error given by composer is:

```
Loading composer repositories with package information
Reading composer.json of colourstream/cron-bundle (master)
Skipped branch master, Could not parse version constraint >=2.1.*: Invalid version string "2.1.*"
```
